### PR TITLE
A3: Add monitoring setup and configuration files for Grafana

### DIFF
--- a/kubernetes/SETUP.md
+++ b/kubernetes/SETUP.md
@@ -1,0 +1,238 @@
+# Sentiment Analysis Application Setup Guide
+
+This guide will walk you through setting up the complete sentiment analysis application from scratch, including both the model service and the web application.
+
+## Prerequisites
+
+- Docker installed
+- Minikube installed
+- kubectl configured
+- Git repository cloned
+
+## Step 1: Initial Setup
+
+1. Start Minikube:
+```bash
+minikube start
+```
+
+2. Clone both repositories (if not done already):
+```bash
+# Clone the operation repository
+git clone https://github.com/remla25-team14/operation.git
+
+# Clone the app repository (if separate)
+git clone https://github.com/remla25-team14/app.git
+```
+
+## Step 2: Build and Test Images Locally
+
+1. Navigate to the operation directory:
+```bash
+cd operation
+```
+
+2. Create GitHub token file:
+```bash
+# Create secrets directory if it doesn't exist
+mkdir -p secrets
+
+# Add your GitHub token to the file
+echo "your-github-token" > secrets/github_token.txt
+```
+
+3. Pull and build the images using Docker Compose:
+```bash
+# Pull the model service image
+docker compose pull model-service
+
+# Build the app image
+docker compose build app
+```
+
+4. Test the services locally:
+```bash
+# Start both services
+docker compose up
+
+# In a new terminal, test if the services are running:
+curl http://localhost:5001  # Should return the web interface
+curl http://localhost:5000/health  # Should return model service health status
+```
+
+## Step 3: Kubernetes Deployment
+
+1. Create the GitHub token secret in Kubernetes:
+```bash
+kubectl create secret generic github-token --from-file=GITHUB_TOKEN=operation/secrets/github_token.txt
+```
+
+2. Deploy Prometheus and Grafana for monitoring:
+```bash
+# Add Prometheus Helm repository
+helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+helm repo update
+
+# Install Prometheus and Grafana stack
+helm install myprom prometheus-community/kube-prometheus-stack
+```
+
+3. Deploy the model service:
+```bash
+kubectl apply -f app/kubernetes/model-deployment.yaml
+```
+
+4. Deploy the sentiment analysis app and monitoring:
+```bash
+kubectl apply -f app/kubernetes/monitoring.yml
+```
+
+5. Verify all pods are running:
+```bash
+kubectl get pods
+
+# Expected output should show:
+# - sentiment-model pod (Running)
+# - sentiment-app pod (Running)
+# - Prometheus pods (Running)
+# - Grafana pods (Running)
+```
+
+## Step 4: Access the Applications
+
+1. Get the sentiment analysis app URL:
+```bash
+minikube service sentiment-app-service --url
+```
+
+2. Access Grafana dashboard:
+```bash
+# Get Grafana admin password
+kubectl get secret myprom-grafana -o jsonpath="{.data.admin-password}" | base64 --decode; echo
+
+# Set up port forwarding for Grafana
+kubectl port-forward service/myprom-grafana 3000:80
+```
+
+3. Configure Grafana:
+- Open http://localhost:3000 in your browser
+- Login with:
+  * Username: admin
+  * Password: (use the password obtained from the previous command)
+  * Note: If you need to get the password again later, you can always run:
+    ```bash
+    kubectl get secret myprom-grafana -o jsonpath="{.data.admin-password}" | base64 --decode; echo
+    ```
+- Import the dashboard from `app/kubernetes/grafana_dashboard.json`
+- If you need to stop port forwarding, use Ctrl+C in the terminal where you ran the port-forward command
+- To restart Grafana access later, just run the port-forward command again:
+  ```bash
+  kubectl port-forward service/myprom-grafana 3000:80
+  ```
+
+## Step 5: Test the Application
+
+1. Test the sentiment analysis:
+- Open the application URL from step 4.1
+- Enter a text in the input field
+- Click "Analyze" to see the sentiment prediction
+
+2. Monitor the metrics:
+- Open Grafana (http://localhost:3000)
+- Navigate to the imported dashboard
+- You should see:
+  * Request Rate by Sentiment
+  * Average Response Time
+  * Positive Sentiment Ratio
+  * Application Version
+
+## Troubleshooting
+
+### Common Issues and Solutions
+
+1. **Image Pull Errors**
+- If `sentiment-app` shows `ErrImageNeverPull`:
+  ```bash
+  # Ensure you've built the image locally
+  cd operation
+  docker compose build app
+  ```
+
+2. **Image Registry and Pull Policy Issues**
+- If you see `ImagePullBackOff` or permission-related errors:
+  * Check your deployment's image pull policy:
+    ```bash
+    kubectl describe deployment sentiment-app
+    ```
+  * For local images, ensure:
+    1. The image is built locally (`docker compose build app`)
+    2. The deployment uses `imagePullPolicy: Never`
+    3. Update your deployment YAML:
+    ```yaml
+    spec:
+      containers:
+      - name: sentiment-app
+        image: sentiment-app:latest
+        imagePullPolicy: Never
+    ```
+  * For GitHub Container Registry (ghcr.io) images:
+    1. Ensure you have a valid GitHub token with `read:packages` scope
+    2. Create a Kubernetes secret for GitHub authentication:
+    ```bash
+    kubectl create secret docker-registry github-registry \
+      --docker-server=ghcr.io \
+      --docker-username=YOUR_GITHUB_USERNAME \
+      --docker-password=YOUR_GITHUB_TOKEN
+    ```
+    3. Add the secret to your deployment:
+    ```yaml
+    spec:
+      imagePullSecrets:
+      - name: github-registry
+      containers:
+      - name: sentiment-app
+        image: ghcr.io/your-org/sentiment-app:latest
+        imagePullPolicy: Always
+    ```
+
+3. **Model Service Issues**
+- If the model service fails to start:
+  * Verify the GitHub token is correct
+  * Check the logs: `kubectl logs deployment/sentiment-model`
+
+4. **Monitoring Issues**
+- If metrics aren't showing in Grafana:
+  * Verify ServiceMonitor is running
+  * Check Prometheus target status in Grafana
+
+### Useful Commands
+
+```bash
+# View pod logs
+kubectl logs <pod-name>
+
+# Describe pod status
+kubectl describe pod <pod-name>
+
+# Restart a deployment
+kubectl rollout restart deployment <deployment-name>
+
+# View all resources
+kubectl get all
+```
+
+## Cleanup
+
+To remove everything:
+```bash
+# Delete Kubernetes resources
+kubectl delete -f app/kubernetes/monitoring.yml
+kubectl delete -f app/kubernetes/model-deployment.yaml
+helm uninstall myprom
+
+# Stop Minikube
+minikube stop
+
+# Optional: Delete Minikube cluster
+minikube delete
+``` 

--- a/kubernetes/grafana-dashboard-config.yaml
+++ b/kubernetes/grafana-dashboard-config.yaml
@@ -1,0 +1,403 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboards
+  labels:
+    grafana_dashboard: "1"  # Label that Grafana will look for
+data:
+  sentiment-dashboard.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 4,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.0",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "sum(rate(sentiment_predictions_total[5m])) by (sentiment)",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Request Rate by Sentiment",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "rate(model_response_time_seconds_sum[5m])\n/\nrate(model_response_time_seconds_count[5m])",
+              "hide": false,
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Average Response Time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "dark-red",
+                    "value": 0
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.3
+                  },
+                  {
+                    "color": "dark-green",
+                    "value": 0.7
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "id": 2,
+          "options": {
+            "minVizHeight": 75,
+            "minVizWidth": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "12.0.0",
+          "targets": [
+            {
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "sentiment_ratio",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Positive Sentiment Ratio",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Current version of the sentiment-analysis",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 1,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "12.0.0",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "disableTextWrap": false,
+              "editorMode": "builder",
+              "expr": "app_info",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A",
+              "useBackend": false
+            }
+          ],
+          "title": "Application Version",
+          "type": "stat"
+        }
+      ],
+      "refresh": "5s",
+      "schemaVersion": 41,
+      "tags": [],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-30m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Sentiment Analysis Dashboard",
+      "uid": "sentiment-analysis",
+      "version": 1
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-config
+data:
+  provider.yaml: |
+    apiVersion: 1
+    providers:
+    - name: 'default'
+      orgId: 1
+      folder: ''
+      type: file
+      disableDeletion: false
+      editable: true
+      options:
+        path: /etc/grafana/provisioning/dashboards 

--- a/kubernetes/grafana-deployment.yaml
+++ b/kubernetes/grafana-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: grafana
+  template:
+    metadata:
+      labels:
+        app: grafana
+    spec:
+      containers:
+      - name: grafana
+        image: grafana/grafana:latest
+        ports:
+        - containerPort: 3000
+        volumeMounts:
+        - name: grafana-dashboard-config
+          mountPath: /etc/grafana/provisioning/dashboards/provider.yaml
+          subPath: provider.yaml
+        - name: grafana-dashboards
+          mountPath: /etc/grafana/provisioning/dashboards
+      volumes:
+      - name: grafana-dashboard-config
+        configMap:
+          name: grafana-dashboard-config
+      - name: grafana-dashboards
+        configMap:
+          name: grafana-dashboards
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana
+spec:
+  selector:
+    app: grafana
+  ports:
+  - port: 3000
+    targetPort: 3000
+  type: LoadBalancer 


### PR DESCRIPTION
Automated Grafana Dashboard Configuration and Setup

This PR automates the previously manual process of setting up the Grafana dashboard for our sentiment analysis monitoring. Instead of manually importing the JSON dashboard configuration, the dashboard is now automatically provisioned during deployment through Kubernetes ConfigMaps.

Added three key files:
- kubernetes/SETUP.md: Complete setup guide including monitoring configuration
- kubernetes/grafana-dashboard-config.yaml: Dashboard configuration and metrics visualization
- kubernetes/grafana-deployment.yaml: Grafana deployment with automatic dashboard loading

The dashboard maintains all existing metrics (request rates, response times, sentiment ratios, and app version) but now requires zero manual configuration. This change ensures consistent monitoring setup across all environments and makes dashboard modifications trackable through version control.

Testing is straightforward - simply apply the new yaml files and the dashboard will be automatically available in Grafana.